### PR TITLE
Refactor/secrets-manager-pattern

### DIFF
--- a/minimax/griptape_nodes_library.json
+++ b/minimax/griptape_nodes_library.json
@@ -3,10 +3,12 @@
   "library_schema_version": "0.1.0",
   "settings": [
     {
-      "description": "Environment variables for storing secrets for new AI service's nodes",
-      "category": "nodes.Minimax",
+      "description": "API keys required by nodes in this library",
+      "category": "app_events.on_app_initialization_complete",
       "contents": {
-          "MINIMAX_API_KEY": "$MINIMAX_API_KEY"
+        "secrets_to_register": [
+          "MINIMAX_API_KEY"
+        ]
       }
     }
   ],

--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -411,7 +411,9 @@ class MinimaxFirstLastFrameToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -15,6 +15,7 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -411,8 +412,6 @@ class MinimaxFirstLastFrameToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -438,7 +438,9 @@ class MinimaxImageToImage(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -15,6 +15,7 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -438,8 +439,6 @@ class MinimaxImageToImage(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -15,6 +15,7 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -442,8 +443,6 @@ class MinimaxImageToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -442,7 +442,9 @@ class MinimaxImageToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_music_generation.py
+++ b/minimax/minimax_music_generation.py
@@ -12,6 +12,7 @@ from griptape.artifacts import AudioUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -263,8 +264,6 @@ class MinimaxMusicGeneration(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()

--- a/minimax/minimax_music_generation.py
+++ b/minimax/minimax_music_generation.py
@@ -263,7 +263,9 @@ class MinimaxMusicGeneration(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_text_to_image.py
+++ b/minimax/minimax_text_to_image.py
@@ -12,6 +12,7 @@ from griptape.artifacts import ImageUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -352,8 +353,6 @@ class MinimaxTextToImage(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()

--- a/minimax/minimax_text_to_image.py
+++ b/minimax/minimax_text_to_image.py
@@ -352,7 +352,9 @@ class MinimaxTextToImage(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_text_to_video.py
+++ b/minimax/minimax_text_to_video.py
@@ -353,7 +353,9 @@ class MinimaxTextToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_NAME)
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/minimax/minimax_text_to_video.py
+++ b/minimax/minimax_text_to_video.py
@@ -12,6 +12,7 @@ from griptape.artifacts import VideoUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -353,8 +354,6 @@ class MinimaxTextToVideo(DataNode):
 
     def _validate_api_key(self) -> str:
         """Validate and return the API key."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-        
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()


### PR DESCRIPTION
- Changed from direct environment variable mapping to secrets_to_register array
- Updated description to match standard library pattern
- Maintains MINIMAX_API_KEY secret registration
- Aligns with SecretsManager refactoring