### PR TITLE
fix: add ExistingFilePolicy.CREATE_NEW to all save_static_file calls to prevent race conditions

### DIFF
--- a/minimax/griptape_nodes_library.json
+++ b/minimax/griptape_nodes_library.json
@@ -15,8 +15,8 @@
   "metadata": {
     "author": "Ian Massingham",
     "description": "Nodes to use Minimax API",
-    "library_version": "0.1.0",
-    "engine_version": "0.55.0",
+    "library_version": "0.1.1",
+    "engine_version": "0.66.0",
     "tags": [
       "Griptape",
       "AI",

--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -16,6 +16,7 @@ from PIL import Image
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -732,7 +733,7 @@ class MinimaxFirstLastFrameToVideo(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename)
+                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 # Create VideoUrlArtifact
                 self.parameter_output_values["video_url"] = VideoUrlArtifact(

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -16,6 +16,7 @@ from PIL import Image
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -666,7 +667,7 @@ class MinimaxImageToImage(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(image_bytes, filename)
+                saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 self._log(f"Saved image {index + 1} to static storage as {filename}")
                 return ImageUrlArtifact(value=saved_url, name=filename)

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -16,6 +16,7 @@ from PIL import Image
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -752,7 +753,7 @@ class MinimaxImageToVideo(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename)
+                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 # Create VideoUrlArtifact
                 self.parameter_output_values["video_url"] = VideoUrlArtifact(

--- a/minimax/minimax_music_generation.py
+++ b/minimax/minimax_music_generation.py
@@ -13,6 +13,7 @@ from griptape.artifacts import AudioUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -349,7 +350,7 @@ class MinimaxMusicGeneration(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(audio_bytes, filename)
+                saved_url = static_files_manager.save_static_file(audio_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 # Create AudioUrlArtifact
                 self.parameter_output_values["audio_url"] = AudioUrlArtifact(

--- a/minimax/minimax_text_to_image.py
+++ b/minimax/minimax_text_to_image.py
@@ -13,6 +13,7 @@ from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -501,7 +502,7 @@ class MinimaxTextToImage(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(image_bytes, filename)
+                saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 # Create and return ImageUrlArtifact
                 image_artifact = ImageUrlArtifact(

--- a/minimax/minimax_text_to_video.py
+++ b/minimax/minimax_text_to_video.py
@@ -13,6 +13,7 @@ from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -513,7 +514,7 @@ class MinimaxTextToVideo(DataNode):
                 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
                 
                 static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename)
+                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
                 
                 # Create VideoUrlArtifact
                 self.parameter_output_values["video_url"] = VideoUrlArtifact(


### PR DESCRIPTION
## Summary
Updates all save_static_file calls to use ExistingFilePolicy.CREATE_NEW to prevent race conditions when multiple nodes run in parallel.

## Important!!!
Do not merge until https://github.com/griptape-ai/griptape-nodes/pull/3374 has made to a stable release. This requires a new parameter to be available to `StaticFilesManager().save_static_file`

## Changes
- Added ExistingFilePolicy import to all affected files
- Updated save_static_file calls to use CREATE_NEW policy for automatic filename collision handling
- Affects 6 files: all Minimax generation nodes (text-to-image, image-to-image, video generation, music generation)

## Test Plan
- [ ] Manually test parallel execution of nodes to verify no file conflicts occur

Fixes https://github.com/griptape-ai/griptape-nodes/issues/3373