### PR TITLE
feat: replace bespoke loading logic with File class

### DIFF
--- a/minimax/griptape_nodes_library.json
+++ b/minimax/griptape_nodes_library.json
@@ -16,7 +16,7 @@
     "author": "Ian Massingham",
     "description": "Nodes to use Minimax API",
     "library_version": "0.1.1",
-    "engine_version": "0.66.0",
+    "engine_version": "0.75.0",
     "tags": [
       "Griptape",
       "AI",

--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -497,14 +497,8 @@ class MinimaxFirstLastFrameToVideo(DataNode):
             if url.startswith(('http://localhost', 'http://127.0.0.1', 'https://localhost', 'https://127.0.0.1')):
                 self._log(f"Converting localhost URL to base64: {url[:100]}...")
                 try:
-                    response = requests.get(url, timeout=30)
-                    response.raise_for_status()
-                    image_bytes = response.content
-                    
-                    # Detect format from response
-                    mime_type = response.headers.get('content-type', 'image/jpeg')
-                    if not mime_type.startswith('image/'):
-                        mime_type = 'image/jpeg'
+                    image_bytes = File(url).read_bytes()
+                    mime_type = 'image/jpeg'
                     
                     # Detect and convert unsupported formats with PIL
                     try:

--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -19,6 +19,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxFirstLastFrameToVideo"]
@@ -720,36 +722,24 @@ class MinimaxFirstLastFrameToVideo(DataNode):
 
     def _save_video_from_url(self, video_url: str) -> None:
         """Save video from URL to static storage."""
-        try:
-            self._log("Processing generated video URL")
-            
-            # Download video bytes
-            video_bytes = self._download_bytes_from_url(video_url)
-            if video_bytes:
-                # Generate filename with timestamp
-                filename = f"minimax_f2l_{int(time.time())}.mp4"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                # Create VideoUrlArtifact
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(
-                    value=saved_url, 
-                    name=filename
-                )
-                self._log(f"Saved video to static storage as {filename}")
-            else:
-                # Fallback to original URL if download fails
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-                self._log("Using original video URL (download failed)")
-                
-        except Exception as e:
-            self._log(f"Failed to save video from URL: {e}")
-            # Fallback to original URL
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
+        self._log("Processing generated video URL")
+
+        # Download video bytes
+        video_bytes = File(video_url).read_bytes()
+
+        # Generate filename with timestamp
+        filename = f"minimax_f2l_{int(time.time())}.mp4"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        # Create VideoUrlArtifact
+        self.parameter_output_values["video_url"] = VideoUrlArtifact(
+            value=saved_url,
+            name=filename
+        )
+        self._log(f"Saved video to static storage as {filename}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
@@ -757,13 +747,4 @@ class MinimaxFirstLastFrameToVideo(DataNode):
         self.parameter_output_values["task_id"] = ""
         self.parameter_output_values["provider_response"] = None
 
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download video bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=120)  # Longer timeout for videos
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None
 

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -20,6 +20,8 @@ from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxImageToImage"]
@@ -652,34 +654,22 @@ class MinimaxImageToImage(DataNode):
             self.parameter_output_values["image"] = saved_artifacts[0]
             self.parameter_output_values["images"] = saved_artifacts
 
-    def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact | None:
+    def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact:
         """Save image from URL to static storage."""
-        try:
-            self._log(f"Downloading image {index + 1} from URL")
-            
-            # Download image bytes
-            image_bytes = self._download_bytes_from_url(image_url)
-            if image_bytes:
-                # Generate filename with timestamp and index
-                filename = f"minimax_image_{int(time.time())}_{index}.png"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                self._log(f"Saved image {index + 1} to static storage as {filename}")
-                return ImageUrlArtifact(value=saved_url, name=filename)
-            else:
-                # Fallback to original URL if download fails
-                self._log(f"Using original image URL for image {index + 1} (download failed)")
-                return ImageUrlArtifact(value=image_url)
-                
-        except Exception as e:
-            self._log(f"Failed to save image {index + 1} from URL: {e}")
-            # Fallback to original URL
-            return ImageUrlArtifact(value=image_url)
+        self._log(f"Downloading image {index + 1} from URL")
+
+        # Download image bytes
+        image_bytes = File(image_url).read_bytes()
+
+        # Generate filename with timestamp and index
+        filename = f"minimax_image_{int(time.time())}_{index}.png"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        self._log(f"Saved image {index + 1} to static storage as {filename}")
+        return ImageUrlArtifact(value=saved_url, name=filename)
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
@@ -687,13 +677,4 @@ class MinimaxImageToImage(DataNode):
         self.parameter_output_values["images"] = []
         self.parameter_output_values["provider_response"] = None
 
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download image bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=30)
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None
 

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -464,9 +464,7 @@ class MinimaxImageToImage(DataNode):
                     self._log("Detected localhost URL, converting to base64")
                     # Download and convert to base64
                     try:
-                        response = requests.get(url, timeout=30)
-                        response.raise_for_status()
-                        image_bytes = response.content
+                        image_bytes = File(url).read_bytes()
                         
                         # Open image and check format
                         img = Image.open(BytesIO(image_bytes))

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -19,6 +19,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxImageToVideo"]
@@ -740,36 +742,24 @@ class MinimaxImageToVideo(DataNode):
 
     def _save_video_from_url(self, video_url: str) -> None:
         """Save video from URL to static storage."""
-        try:
-            self._log("Processing generated video URL")
-            
-            # Download video bytes
-            video_bytes = self._download_bytes_from_url(video_url)
-            if video_bytes:
-                # Generate filename with timestamp
-                filename = f"minimax_i2v_{int(time.time())}.mp4"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                # Create VideoUrlArtifact
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(
-                    value=saved_url, 
-                    name=filename
-                )
-                self._log(f"Saved video to static storage as {filename}")
-            else:
-                # Fallback to original URL if download fails
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-                self._log("Using original video URL (download failed)")
-                
-        except Exception as e:
-            self._log(f"Failed to save video from URL: {e}")
-            # Fallback to original URL
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
+        self._log("Processing generated video URL")
+
+        # Download video bytes
+        video_bytes = File(video_url).read_bytes()
+
+        # Generate filename with timestamp
+        filename = f"minimax_i2v_{int(time.time())}.mp4"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        # Create VideoUrlArtifact
+        self.parameter_output_values["video_url"] = VideoUrlArtifact(
+            value=saved_url,
+            name=filename
+        )
+        self._log(f"Saved video to static storage as {filename}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
@@ -777,13 +767,4 @@ class MinimaxImageToVideo(DataNode):
         self.parameter_output_values["task_id"] = ""
         self.parameter_output_values["provider_response"] = None
 
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download video bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=120)  # Longer timeout for videos
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None
 

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -523,14 +523,8 @@ class MinimaxImageToVideo(DataNode):
             if url.startswith(('http://localhost', 'http://127.0.0.1', 'https://localhost', 'https://127.0.0.1')):
                 self._log(f"Converting localhost URL to base64: {url[:100]}...")
                 try:
-                    response = requests.get(url, timeout=30)
-                    response.raise_for_status()
-                    image_bytes = response.content
-                    
-                    # Detect format from response
-                    mime_type = response.headers.get('content-type', 'image/jpeg')
-                    if not mime_type.startswith('image/'):
-                        mime_type = 'image/jpeg'
+                    image_bytes = File(url).read_bytes()
+                    mime_type = 'image/jpeg'
                     
                     # Detect and convert unsupported formats with PIL
                     try:

--- a/minimax/minimax_music_generation.py
+++ b/minimax/minimax_music_generation.py
@@ -17,6 +17,8 @@ from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxMusicGeneration"]
@@ -337,49 +339,28 @@ class MinimaxMusicGeneration(DataNode):
 
     def _save_audio_from_url(self, audio_url: str, audio_format: str) -> None:
         """Save audio from URL to static storage."""
-        try:
-            self._log("Downloading generated audio from URL")
-            
-            # Download audio bytes
-            audio_bytes = self._download_bytes_from_url(audio_url)
-            if audio_bytes:
-                # Generate filename with timestamp
-                filename = f"minimax_music_{int(time.time())}.{audio_format}"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(audio_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                # Create AudioUrlArtifact
-                self.parameter_output_values["audio_url"] = AudioUrlArtifact(
-                    value=saved_url, 
-                    name=filename
-                )
-                self._log(f"Saved audio to static storage as {filename}")
-            else:
-                # Fallback to original URL if download fails
-                self.parameter_output_values["audio_url"] = AudioUrlArtifact(value=audio_url)
-                self._log("Using original audio URL (download failed)")
-                
-        except Exception as e:
-            self._log(f"Failed to save audio from URL: {e}")
-            # Fallback to original URL
-            self.parameter_output_values["audio_url"] = AudioUrlArtifact(value=audio_url)
+        self._log("Downloading generated audio from URL")
+
+        # Download audio bytes
+        audio_bytes = File(audio_url).read_bytes()
+
+        # Generate filename with timestamp
+        filename = f"minimax_music_{int(time.time())}.{audio_format}"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(audio_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        # Create AudioUrlArtifact
+        self.parameter_output_values["audio_url"] = AudioUrlArtifact(
+            value=saved_url,
+            name=filename
+        )
+        self._log(f"Saved audio to static storage as {filename}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
         self.parameter_output_values["audio_url"] = None
         self.parameter_output_values["provider_response"] = None
 
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download audio bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=120)
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None
 

--- a/minimax/minimax_text_to_image.py
+++ b/minimax/minimax_text_to_image.py
@@ -17,6 +17,8 @@ from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxTextToImage"]
@@ -486,41 +488,28 @@ class MinimaxTextToImage(DataNode):
             self.parameter_output_values["image_url"] = None
             self.parameter_output_values["images"] = []
 
-    def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact | None:
+    def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact:
         """Save image from URL to static storage and return ImageUrlArtifact."""
-        try:
-            self._log(f"Processing generated image URL {index + 1}")
-            
-            # Download image bytes
-            image_bytes = self._download_bytes_from_url(image_url)
-            if image_bytes:
-                # Generate filename with timestamp and index
-                timestamp = int(time.time())
-                filename = f"minimax_image_{timestamp}_{index + 1}.jpg"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                # Create and return ImageUrlArtifact
-                image_artifact = ImageUrlArtifact(
-                    value=saved_url, 
-                    name=filename
-                )
-                self._log(f"Saved image {index + 1} to static storage as {filename}")
-                return image_artifact
-            else:
-                # Fallback to original URL if download fails
-                image_artifact = ImageUrlArtifact(value=image_url)
-                self._log(f"Using original image URL for image {index + 1} (download failed)")
-                return image_artifact
-                
-        except Exception as e:
-            self._log(f"Failed to save image {index + 1} from URL: {e}")
-            # Fallback to original URL
-            return ImageUrlArtifact(value=image_url)
+        self._log(f"Processing generated image URL {index + 1}")
+
+        # Download image bytes
+        image_bytes = File(image_url).read_bytes()
+
+        # Generate filename with timestamp and index
+        timestamp = int(time.time())
+        filename = f"minimax_image_{timestamp}_{index + 1}.jpg"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        # Create and return ImageUrlArtifact
+        image_artifact = ImageUrlArtifact(
+            value=saved_url,
+            name=filename
+        )
+        self._log(f"Saved image {index + 1} to static storage as {filename}")
+        return image_artifact
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
@@ -528,13 +517,3 @@ class MinimaxTextToImage(DataNode):
         self.parameter_output_values["generation_id"] = ""
         self.parameter_output_values["provider_response"] = None
         self.parameter_output_values["images"] = []
-
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download image bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=120)
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None

--- a/minimax/minimax_text_to_video.py
+++ b/minimax/minimax_text_to_video.py
@@ -16,6 +16,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes.files.file import File, FileLoadError
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MinimaxTextToVideo"]
@@ -501,36 +503,24 @@ class MinimaxTextToVideo(DataNode):
 
     def _save_video_from_url(self, video_url: str) -> None:
         """Save video from URL to static storage."""
-        try:
-            self._log("Processing generated video URL")
-            
-            # Download video bytes
-            video_bytes = self._download_bytes_from_url(video_url)
-            if video_bytes:
-                # Generate filename with timestamp
-                filename = f"minimax_video_{int(time.time())}.mp4"
-                
-                # Save to static storage
-                from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-                
-                static_files_manager = GriptapeNodes.StaticFilesManager()
-                saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-                
-                # Create VideoUrlArtifact
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(
-                    value=saved_url, 
-                    name=filename
-                )
-                self._log(f"Saved video to static storage as {filename}")
-            else:
-                # Fallback to original URL if download fails
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-                self._log("Using original video URL (download failed)")
-                
-        except Exception as e:
-            self._log(f"Failed to save video from URL: {e}")
-            # Fallback to original URL
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
+        self._log("Processing generated video URL")
+
+        # Download video bytes
+        video_bytes = File(video_url).read_bytes()
+
+        # Generate filename with timestamp
+        filename = f"minimax_video_{int(time.time())}.mp4"
+
+        # Save to static storage
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        # Create VideoUrlArtifact
+        self.parameter_output_values["video_url"] = VideoUrlArtifact(
+            value=saved_url,
+            name=filename
+        )
+        self._log(f"Saved video to static storage as {filename}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""
@@ -538,12 +528,3 @@ class MinimaxTextToVideo(DataNode):
         self.parameter_output_values["task_id"] = ""
         self.parameter_output_values["provider_response"] = None
 
-    @staticmethod
-    def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download video bytes from URL."""
-        try:
-            resp = requests.get(url, timeout=120)  # Longer timeout for videos
-            resp.raise_for_status()
-            return resp.content
-        except Exception:
-            return None


### PR DESCRIPTION
## Summary
- Remove `_download_bytes_from_url` static methods and replace callers with `File(url).read_bytes()`
- Bump `engine_version` to `0.75.0`
- API submit/poll/retrieve calls are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)