### PR TITLE
feat: migrate save_static_file to ProjectFileParameter

### DIFF
--- a/minimax/minimax_first_last_frame_to_video.py
+++ b/minimax/minimax_first_last_frame_to_video.py
@@ -15,8 +15,8 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes.files.file import File, FileLoadError
@@ -76,7 +76,9 @@ class MinimaxFirstLastFrameToVideo(DataNode):
         super().__init__(**kwargs)
         self.category = "Video Generation"
         self.description = "Generate videos using Minimax first-frame-to-last-frame API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_f2l.mp4")
+        self._output_file.add_parameter()
+
         # First frame image parameter
         self.add_parameter(
             Parameter(
@@ -715,25 +717,21 @@ class MinimaxFirstLastFrameToVideo(DataNode):
             raise RuntimeError(f"Failed to retrieve video file: {e}")
 
     def _save_video_from_url(self, video_url: str) -> None:
-        """Save video from URL to static storage."""
+        """Save video from URL to project storage."""
         self._log("Processing generated video URL")
 
         # Download video bytes
         video_bytes = File(video_url).read_bytes()
 
-        # Generate filename with timestamp
-        filename = f"minimax_f2l_{int(time.time())}.mp4"
-
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(video_bytes)
 
         # Create VideoUrlArtifact
         self.parameter_output_values["video_url"] = VideoUrlArtifact(
-            value=saved_url,
-            name=filename
+            value=saved.location,
+            name=saved.location
         )
-        self._log(f"Saved video to static storage as {filename}")
+        self._log(f"Saved video to project storage as {saved.location}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""

--- a/minimax/minimax_image_to_image.py
+++ b/minimax/minimax_image_to_image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import json as _json
 import logging
-import time
 from contextlib import suppress
 from copy import deepcopy
 from io import BytesIO
@@ -15,8 +14,8 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -82,7 +81,9 @@ class MinimaxImageToImage(DataNode):
         super().__init__(**kwargs)
         self.category = "Image Generation"
         self.description = "Generate images using Minimax image-to-image API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_image.png")
+        self._output_file.add_parameter()
+
         # Core prompt parameter
         self.add_parameter(
             Parameter(
@@ -653,21 +654,17 @@ class MinimaxImageToImage(DataNode):
             self.parameter_output_values["images"] = saved_artifacts
 
     def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact:
-        """Save image from URL to static storage."""
+        """Save image from URL to project storage."""
         self._log(f"Downloading image {index + 1} from URL")
 
         # Download image bytes
         image_bytes = File(image_url).read_bytes()
 
-        # Generate filename with timestamp and index
-        filename = f"minimax_image_{int(time.time())}_{index}.png"
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(image_bytes)
 
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-
-        self._log(f"Saved image {index + 1} to static storage as {filename}")
-        return ImageUrlArtifact(value=saved_url, name=filename)
+        self._log(f"Saved image {index + 1} to project storage as {saved.location}")
+        return ImageUrlArtifact(value=saved.location, name=saved.location)
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""

--- a/minimax/minimax_image_to_video.py
+++ b/minimax/minimax_image_to_video.py
@@ -15,8 +15,8 @@ from PIL import Image
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes.files.file import File, FileLoadError
@@ -83,7 +83,9 @@ class MinimaxImageToVideo(DataNode):
         super().__init__(**kwargs)
         self.category = "Video Generation"
         self.description = "Generate videos using Minimax image-to-video API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_i2v.mp4")
+        self._output_file.add_parameter()
+
         # First frame image parameter
         self.add_parameter(
             Parameter(
@@ -735,25 +737,21 @@ class MinimaxImageToVideo(DataNode):
             raise RuntimeError(f"Failed to retrieve video file: {e}")
 
     def _save_video_from_url(self, video_url: str) -> None:
-        """Save video from URL to static storage."""
+        """Save video from URL to project storage."""
         self._log("Processing generated video URL")
 
         # Download video bytes
         video_bytes = File(video_url).read_bytes()
 
-        # Generate filename with timestamp
-        filename = f"minimax_i2v_{int(time.time())}.mp4"
-
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(video_bytes)
 
         # Create VideoUrlArtifact
         self.parameter_output_values["video_url"] = VideoUrlArtifact(
-            value=saved_url,
-            name=filename
+            value=saved.location,
+            name=saved.location
         )
-        self._log(f"Saved video to static storage as {filename}")
+        self._log(f"Saved video to project storage as {saved.location}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""

--- a/minimax/minimax_music_generation.py
+++ b/minimax/minimax_music_generation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json as _json
 import logging
-import time
 from contextlib import suppress
 from copy import deepcopy
 from typing import Any
@@ -12,8 +11,8 @@ from griptape.artifacts import AudioUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -66,7 +65,9 @@ class MinimaxMusicGeneration(DataNode):
         super().__init__(**kwargs)
         self.category = "Audio Generation"
         self.description = "Generate music using Minimax music generation API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_music.mp3")
+        self._output_file.add_parameter()
+
         # Prompt parameter
         self.add_parameter(
             Parameter(
@@ -338,25 +339,21 @@ class MinimaxMusicGeneration(DataNode):
             self._log(f"Request payload: {_json.dumps(sanitized_payload, indent=2)}")
 
     def _save_audio_from_url(self, audio_url: str, audio_format: str) -> None:
-        """Save audio from URL to static storage."""
+        """Save audio from URL to project storage."""
         self._log("Downloading generated audio from URL")
 
         # Download audio bytes
         audio_bytes = File(audio_url).read_bytes()
 
-        # Generate filename with timestamp
-        filename = f"minimax_music_{int(time.time())}.{audio_format}"
-
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(audio_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(audio_bytes)
 
         # Create AudioUrlArtifact
         self.parameter_output_values["audio_url"] = AudioUrlArtifact(
-            value=saved_url,
-            name=filename
+            value=saved.location,
+            name=saved.location
         )
-        self._log(f"Saved audio to static storage as {filename}")
+        self._log(f"Saved audio to project storage as {saved.location}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""

--- a/minimax/minimax_text_to_image.py
+++ b/minimax/minimax_text_to_image.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json as _json
 import logging
-import time
 from contextlib import suppress
 from copy import deepcopy
 from typing import Any
@@ -12,8 +11,8 @@ from griptape.artifacts import ImageUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -77,7 +76,9 @@ class MinimaxTextToImage(DataNode):
         super().__init__(**kwargs)
         self.category = "Image Generation"
         self.description = "Generate images using Minimax text-to-image API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_image.jpg")
+        self._output_file.add_parameter()
+
         # Core prompt parameter
         self.add_parameter(
             Parameter(
@@ -489,27 +490,17 @@ class MinimaxTextToImage(DataNode):
             self.parameter_output_values["images"] = []
 
     def _save_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact:
-        """Save image from URL to static storage and return ImageUrlArtifact."""
+        """Save image from URL to project storage and return ImageUrlArtifact."""
         self._log(f"Processing generated image URL {index + 1}")
 
         # Download image bytes
         image_bytes = File(image_url).read_bytes()
 
-        # Generate filename with timestamp and index
-        timestamp = int(time.time())
-        filename = f"minimax_image_{timestamp}_{index + 1}.jpg"
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(image_bytes)
 
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
-
-        # Create and return ImageUrlArtifact
-        image_artifact = ImageUrlArtifact(
-            value=saved_url,
-            name=filename
-        )
-        self._log(f"Saved image {index + 1} to static storage as {filename}")
-        return image_artifact
+        self._log(f"Saved image {index + 1} to project storage as {saved.location}")
+        return ImageUrlArtifact(value=saved.location, name=saved.location)
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""

--- a/minimax/minimax_text_to_video.py
+++ b/minimax/minimax_text_to_video.py
@@ -12,8 +12,8 @@ from griptape.artifacts import VideoUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes.files.file import File, FileLoadError
@@ -78,7 +78,9 @@ class MinimaxTextToVideo(DataNode):
         super().__init__(**kwargs)
         self.category = "Video Generation"
         self.description = "Generate videos using Minimax text-to-video API"
-        
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="minimax_video.mp4")
+        self._output_file.add_parameter()
+
         # Core prompt parameter
         self.add_parameter(
             Parameter(
@@ -502,25 +504,21 @@ class MinimaxTextToVideo(DataNode):
             raise RuntimeError(f"Failed to retrieve video file: {e}")
 
     def _save_video_from_url(self, video_url: str) -> None:
-        """Save video from URL to static storage."""
+        """Save video from URL to project storage."""
         self._log("Processing generated video URL")
 
         # Download video bytes
         video_bytes = File(video_url).read_bytes()
 
-        # Generate filename with timestamp
-        filename = f"minimax_video_{int(time.time())}.mp4"
-
-        # Save to static storage
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+        # Save to project storage
+        saved = self._output_file.build_file().write_bytes(video_bytes)
 
         # Create VideoUrlArtifact
         self.parameter_output_values["video_url"] = VideoUrlArtifact(
-            value=saved_url,
-            name=filename
+            value=saved.location,
+            name=saved.location
         )
-        self._log(f"Saved video to static storage as {filename}")
+        self._log(f"Saved video to project storage as {saved.location}")
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for all outputs."""


### PR DESCRIPTION
Closes #7

Replace `StaticFilesManager.save_static_file()` with `ProjectFileParameter` for project-aware file saving.